### PR TITLE
Fix warning of NUMBER_OF_MIP_LEVELS

### DIFF
--- a/GLES/source/resources/texture.cpp
+++ b/GLES/source/resources/texture.cpp
@@ -31,7 +31,7 @@
 #include "utils/VkToGlConverter.h"
 #include "utils/glUtils.h"
 
-#define NUMBER_OF_MIP_LEVELS(w, h)                      (std::floor(std::log2(std::max((w),(h)))) + 1)
+#define NUMBER_OF_MIP_LEVELS(w, h)                      (static_cast<GLint>(std::floor(std::log2(std::max((w),(h)))) + 1))
 
 // TODO:: this needs to be further discussed
 int Texture::mDefaultInternalAlignment = 1;


### PR DESCRIPTION
`std::floor` returns float or double, but the return value of `NUMBER_OF_MIP_LEVELS ` assigns to GLint variables. It is a problem maybe. Please take a look at the PR. @abasilak 