### PR TITLE
gl: Return -1 if `glGet*Location` not found based on GL ES spec.

### DIFF
--- a/GLES/source/api/gl.cpp
+++ b/GLES/source/api/gl.cpp
@@ -23,15 +23,17 @@
 
 #include "context/context.h"
 
-#define CONTEXT_EXEC(func)          FUN_ENTRY(GL_LOG_INFO);                      \
-                                    Context * context = GetCurrentContext();     \
-                                    if (context) {                               \
-                                        context->func;                           \
-                                    }
+#define CONTEXT_EXEC(func)                             FUN_ENTRY(GL_LOG_INFO);                      \
+                                                       Context * context = GetCurrentContext();     \
+                                                       if (context) {                               \
+                                                           context->func;                           \
+                                                       }
 
-#define CONTEXT_EXEC_RETURN(func)   FUN_ENTRY(GL_LOG_INFO);                      \
-                                    Context * context = GetCurrentContext();     \
-                                    return context ? context->func : 0;
+#define CONTEXT_EXEC_RETURN_WITH_VALUE(func, retVal)   FUN_ENTRY(GL_LOG_INFO);                      \
+                                                       Context * context = GetCurrentContext();     \
+                                                       return context ? context->func : retVal;
+
+#define CONTEXT_EXEC_RETURN(func)                      CONTEXT_EXEC_RETURN_WITH_VALUE(fuc, 0)
 
 GL_APICALL void GL_APIENTRY
 glActiveTexture(GLenum texture)
@@ -378,7 +380,7 @@ glGetAttachedShaders(GLuint program, GLsizei maxcount, GLsizei* count, GLuint* s
 GL_APICALL int  GL_APIENTRY
 glGetAttribLocation(GLuint program, const char* name)
 {
-    CONTEXT_EXEC_RETURN(GetAttribLocation(program, name));
+    CONTEXT_EXEC_RETURN_WITH_VALUE(GetAttribLocation(program, name), -1);
 }
 
 GL_APICALL void GL_APIENTRY
@@ -492,7 +494,7 @@ glGetUniformiv(GLuint program, GLint location, GLint* params)
 GL_APICALL int  GL_APIENTRY
 glGetUniformLocation(GLuint program, const char* name)
 {
-    CONTEXT_EXEC_RETURN(GetUniformLocation(program, name));
+    CONTEXT_EXEC_RETURN_WITH_VALUE(GetUniformLocation(program, name), -1);
 }
 
 GL_APICALL void GL_APIENTRY


### PR DESCRIPTION
> If the named attribute variable is not an active attribute in the specified program object or if *name* starts with the reserved prefix "gl_", a value of -1 is returned.
>
> http://docs.gl/es2/glGetAttribLocation