### PR TITLE
Fix Vulkan crash during shader creation

### DIFF
--- a/GLES/source/resources/shaderProgram.cpp
+++ b/GLES/source/resources/shaderProgram.cpp
@@ -102,6 +102,7 @@ ShaderProgram::SetPipelineShaderStage(uint32_t &pipelineShaderStageCount, int *p
         pipelineShaderStages[0].stage  = GetShaderStage();
         pipelineShaderStages[0].module = GetShaderModule();
         pipelineShaderStages[0].pName  = "main\0";
+        pipelineShaderStages[0].pSpecializationInfo = nullptr;
         pipelineShaderStagesIDs[0]     = GetStagesIDs(0);
 
         if(GetShaderModule() == VK_NULL_HANDLE) {
@@ -114,6 +115,7 @@ ShaderProgram::SetPipelineShaderStage(uint32_t &pipelineShaderStageCount, int *p
         pipelineShaderStages[0].stage  = VK_SHADER_STAGE_VERTEX_BIT;
         pipelineShaderStages[0].module = GetVertexShaderModule();
         pipelineShaderStages[0].pName  = "main\0";
+        pipelineShaderStages[0].pSpecializationInfo = nullptr;
         pipelineShaderStagesIDs[0]     = GetStagesIDs(0);
 
         if(GetVertexShaderModule() == VK_NULL_HANDLE) {
@@ -126,6 +128,7 @@ ShaderProgram::SetPipelineShaderStage(uint32_t &pipelineShaderStageCount, int *p
         pipelineShaderStages[1].stage  = VK_SHADER_STAGE_FRAGMENT_BIT;
         pipelineShaderStages[1].module = GetFragmentShaderModule();
         pipelineShaderStages[1].pName  = "main\0";
+        pipelineShaderStages[1].pSpecializationInfo = nullptr;
         pipelineShaderStagesIDs[1]     = GetStagesIDs(1);
 
         if(GetFragmentShaderModule() == VK_NULL_HANDLE) {


### PR DESCRIPTION
During implementation of Vulkan on Kodi I found a crash on GLOVE during shader creation.

See gdb log here: https://pastebin.com/eHX78hwx
Crash place: https://github.com/intel/external-mesa/blob/master/src/intel/vulkan/anv_pipeline.c#L437

There by point `#1` on SHA1Update is a `len=24076459264` where is unrealistic.
Seen then by SetPipelineShaderStage on [VkPipelineShaderStageCreateInfo](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineShaderStageCreateInfo.html) that `pSpecializationInfo` can be set to NULL where was not done before. After set of them was the crash away.

All the demos has still worked normal after this change.